### PR TITLE
add help info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,33 @@ mdserver
 markdown http server
 
 ##installation
-    npm install mdserver
-
-if you want to use it from the cli, install it with
 
     npm install mdserver -g
 
 ## usage
 
 ```sh
+✍ mdserver -h
+
+  Usage: mdserver [options]
+
+  Options:
+
+    -h, --help        output usage information
+    -V, --version     output the version number
+    -p, --port <num>  serve with given port
+    -r, --root <path>  serve given path
+
+```
+
+
+## Examples
+
+```sh
 # use current dir and default port 3333
 mdserver
 
 # set root dir and port
-mdserver --port 8788 --root ~/github/mdserver
+mdserver -p 8788 -r ~/github/mdserver
 ```
 ... To be Continued...

--- a/index.js
+++ b/index.js
@@ -1,45 +1,13 @@
 #!/usr/bin/env node
-var app = require('connect')();
-var serveIndex = require('serve-index');
-var serveStatic = require('serve-static');
-var serveMarkdown = require('serve-markdown');
-var merge = require('utils-merge');
-var options = require('minimist')(process.argv.slice(2));
-var chalk = require('chalk');
-var moment = require('moment');
+var program = require('commander');
+var pkg = require('./package.json');
+var serve = require('./lib/server');
 
+program
+    .version(pkg.version)
+    .option('-p, --port <num>', 'serve with given port')
+    .option('-r, --root <path>', 'serve given path')
+    .parse(process.argv);
 
-var defaultOptions = {
-    port: '3333'
-};
-options = merge(defaultOptions, options);
+serve(program.opts());
 
-var root = options.root || process.cwd()
-
-app.use(log);
-app.use(serveMarkdown(root));
-app.use(serveStatic(root, {
-    'index': ['index.html'],
-    'setHeaders': function (res, fp) {
-        res.setHeader('x-powerby', 'zhiyelee')
-    }
-}))
-app.use(serveIndex(root, {'icon': true}))
-
-app.listen(options.port);
-
-// display serve info
-console.log(chalk.blue('serve start Success: ') + chalk.green('http://127.0.0.1:') + chalk.red(options.port) + chalk.green('/'));
-
-function log(req, res, next) {
-    console.log('['
-                + chalk.grey(ts())
-                + '] '
-                + chalk.white(decodeURI(req.url))
-            );
-    next()
-}
-
-function ts() {
-    return moment().format('HH:mm:ss')
-}

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,89 @@
+"use strict";
+var connect = require('connect');
+var serveIndex = require('serve-index');
+var serveStatic = require('serve-static');
+var serveMarkdown = require('serve-markdown');
+var options = require('minimist')(process.argv.slice(2));
+var chalk = require('chalk');
+var moment = require('moment');
+
+
+/**
+ * init options
+ */
+function initOptions(options) {
+    var defaultOptions = {
+        'root': process.cwd(),
+        port: '3333'
+    };
+    return merge(defaultOptions, options);
+}
+
+/**
+ * start server with provided options
+ */
+function startServer(options) {
+
+    options = initOptions(options)
+
+    var app = connect();
+    var root = options.root;
+
+    app.use(log);
+    // serve markdown file
+    app.use(serveMarkdown(root));
+    // common files
+    app.use(serveStatic(root, {'index': ['index.html']}));
+    // directory index
+    app.use(serveIndex(root, {'icon': true}))
+
+    app.listen(options.port);
+
+    // server start success
+    console.log(chalk.blue('serve start Success: ')
+                + '\n'
+                + chalk.green('\t url   ')
+                + chalk.grey('http://127.0.0.1:')
+                + chalk.red(options.port)
+                + chalk.grey('/')
+                + '\n'
+                + chalk.green('\t serve ')
+                + chalk.grey(options.root)
+               );
+}
+
+module.exports = startServer;
+
+/**
+ * simple log middleware, output the access log
+ **/
+function log(req, res, next) {
+    console.log('['
+                + chalk.grey(ts())
+                + '] '
+                + chalk.white(decodeURI(req.url))
+            );
+    next()
+}
+
+/**
+ * get current timestamp
+ */
+function ts() {
+    return moment().format('HH:mm:ss')
+}
+
+/**
+ * simple merge
+ * @description if property `p` of a is not `undefined`, set a[p] = b[p]
+ */
+function merge(a, b) {
+    var hasOwnProperty = Object.prototype.hasOwnProperty;
+    for (var p in b ) {
+        if (hasOwnProperty.call(b, p) && b[p] !== undefined) {
+            a[p] = b[p];
+        }
+    }
+
+    return a;
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "mdserver",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "static http server with markdown support",
   "main": "index.js",
   "bin": "index.js",
   "dependencies": {
     "chalk": "^0.5.1",
+    "commander": "^2.4.0",
     "connect": "^3.3.0",
     "highlight.js": "^8.3.0",
     "marked": "^0.3.2",
@@ -13,8 +14,7 @@
     "moment": "^2.8.3",
     "serve-index": "^1.5.0",
     "serve-markdown": "^0.1.3",
-    "serve-static": "^1.7.0",
-    "utils-merge": "^1.0.0"
+    "serve-static": "^1.7.0"
   },
   "devDependencies": {},
   "repository": "git://github.com/zhiyelee/mdserver.git",


### PR DESCRIPTION
Add help info with commander.js

``` sh
✍ mdserver -h

  Usage: mdserver [options]

  Options:

    -h, --help        output usage information
    -V, --version     output the version number
    -p, --port <num>  serve with given port
    -r, --root <dir>  serve given path

```

resolve #2 
